### PR TITLE
Change declaration `let prev` to `const prev`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const METHODS = [
 
 function wrap(inst) {
   METHODS.forEach(method => {
-    let prev = inst[method];
+    const prev = inst[method];
     if (prev) {
       inst[method] = (...args) => {
         return prev.call(inst, inst.props, inst.state, ...args);


### PR DESCRIPTION
Since you not re-assign `prev` variable, let's change it to use `const` instead of `let` for a better memory saver.

https://ponyfoo.com/articles/var-let-const